### PR TITLE
Homebrew now installs nginx in /usr/local/bin/

### DIFF
--- a/Library/LaunchAgents/org.nginx.plist
+++ b/Library/LaunchAgents/org.nginx.plist
@@ -14,7 +14,7 @@
     <true/>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/sbin/nginx</string>
+        <string>/usr/local/bin/nginx</string>
         <string>-g</string>
         <string>daemon off;</string>
         <string>-c</string>


### PR DESCRIPTION
Hey thanks for this repo! It saved me a lot of time getting nginx set up correctly. :+1: 

I ran into a small issue with the incorrect path being set in the `org.nginx.plist`. It seems that brew now installs it in `/usr/local/bin` instead of `/usr/local/sbin`. It took me a while to figure out the problem, but I finally thought to monitor the launchd logs in the Console.app.
